### PR TITLE
Upgrade key to RSA

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -23,14 +23,13 @@ jobs:
           eval "$(ssh-agent -s)"
 
           # 2. Add the SSH private key from the secret to the agent
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" | ssh-add -
+          echo "${{ secrets.GEMINI_CLI_EXTENSIONS_FLUTTER_MIRROR_KEY }}" | ssh-add -
 
           # 3. Add GitHub's public SSH keys to the known_hosts file for security.
           # Keys are sourced from:
           # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
           mkdir -p ~/.ssh
-          echo "
-          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" >> ~/.ssh/known_hosts
+          echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=" >> ~/.ssh/known_hosts
 
           # 4. Push to the destination repository
           git push --mirror git@github.com:gemini-cli-extensions/flutter.git


### PR DESCRIPTION
Upgrading the key used to be an RSA key instead of `ssh-ed25519`, which is much smaller. Also gave the secret a better name.