### PR TITLE
Remove missing file from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
           git archive --format=tar.gz -o $archive_name $tag_name \
             gemini-extension.json \
             commands/ \
-            override \
             LICENSE \
             README.md \
             flutter.md


### PR DESCRIPTION
# Description

Release building was failing because the override file was removed. Removed it from the release workflow to fix.