### PR TITLE
Make mirroring only happen on main branch, or when a tag is deleted

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,6 +1,10 @@
 name: Mirror To gemini-cli-extensions/flutter
 
-on: [push, delete]
+on:
+  push:
+    branches:
+      - main
+  delete:
 
 # Ensures that only one mirror job runs at a time per branch.
 # Cancels any in-progress job on the same branch if a new push occurs.
@@ -10,6 +14,7 @@ concurrency:
 
 jobs:
   mirror:
+    if: github.event_name == 'push' || (github.event_name == 'delete' && github.event.ref_type == 'tag')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

Fixes the mirroring action to only run on the main branch.