### PR TITLE
Rename /refator to /modify

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,10 +1,10 @@
 # Project Overview
 
-This repository contains a Gemini CLI extension for facilitating Flutter and Dart development. The extension provides a set of commands to streamline common development tasks, including project creation, refactoring, and committing code. It enforces a set of coding standards and best practices for building high-quality Flutter and Dart applications.
+This repository contains a Gemini CLI extension for facilitating Flutter and Dart development. The extension provides a set of commands to streamline common development tasks, including project creation, modification, and committing code. It enforces a set of coding standards and best practices for building high-quality Flutter and Dart applications.
 
 The core of this extension is the `flutter.md` context file, which provides a comprehensive set of rules and guidelines for the AI model. These guidelines cover everything from project structure and coding style to state management and testing.
 
-The extension also includes a set of commands defined in `.toml` files within the `commands` directory. These commands provide a structured way to interact with the AI model for tasks such as creating new apps, refactoring existing code, and preparing changes for commit.
+The extension also includes a set of commands defined in `.toml` files within the `commands` directory. These commands provide a structured way to interact with the AI model for tasks such as creating new apps, modifying existing code, and preparing changes for commit.
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Help Gemini CLI create, build, test, and run Flutter apps.
 
-*   **Status: Experimental** - This is an experimental project. Features and commands may change drastically. We welcome your feedback!
+- **Status: Experimental** - This is an experimental project. Features and commands may change drastically. We welcome your feedback!
 
 ## ✨ Features
 
--   **🚀 Project Bootstrapping**: Create new Flutter projects from scratch with built-in best practices, including linters, documentation, and design planning.
--   **🔧 Guided Refactoring**: Execute complex refactoring tasks with automated planning, git branch management, and step-by-step implementation guides for your approval.
--   **✅ Automated Pre-Commit Checks**: Automatically format, analyze, and test your code before committing to maintain codebase quality.
--   **✍️ Smart Commit Messaging**: Generate descriptive, conventional commit messages based on your staged changes.
--   **🧠 Context Priming**: Initializes Gemini with specific rules and context for Dart and Flutter, ensuring high-quality, idiomatic code generation.
+- **🚀 Project Bootstrapping**: Create new Flutter projects from scratch with built-in best practices, including linters, documentation, and design planning.
+- **🔧 Guided Modifications**: Execute complex modification tasks with automated planning, git branch management, and step-by-step implementation guides for your approval.
+- **✅ Automated Pre-Commit Checks**: Automatically format, analyze, and test your code before committing to maintain codebase quality.
+- **✍️ Smart Commit Messaging**: Generate descriptive, conventional commit messages based on your staged changes.
+- **🧠 Context Priming**: Initializes Gemini with specific rules and context for Dart and Flutter, ensuring high-quality, idiomatic code generation.
 
 ## 📋 Prerequisites
 
@@ -42,9 +42,9 @@ gemini extensions uninstall flutter
 
 The new commands will be available in new Gemini CLI sessions. The following commands will be available (with or without the `flutter:` prefix):
 
--   `/create-app` - Guides you through bootstrapping a new Flutter project with best practices.
--   `/refactor` - Manages a structured refactoring session with automated planning.
--   `/commit` - Automates pre-commit checks and generates a descriptive commit message.
+- `/create-app` - Guides you through bootstrapping a new Flutter project with best practices.
+- `/modify` - Manages a structured modification session with automated planning.
+- `/commit` - Automates pre-commit checks and generates a descriptive commit message.
 
 ## 💡 Usage
 
@@ -55,6 +55,7 @@ This extension provides powerful commands to automate key phases of the developm
 Initiates a guided process to bootstrap a new Flutter application, ensuring your project starts with a solid foundation.
 
 **Process:**
+
 1.  Asks for the package's purpose, details, and desired location on your filesystem.
 2.  Creates a new Flutter project with recommended settings and linter rules.
 3.  Generates starter `pubspec.yaml`, `README.md`, and `CHANGELOG.md` files.
@@ -64,18 +65,19 @@ Initiates a guided process to bootstrap a new Flutter application, ensuring your
 /create-app I want to create a trip planning app
 ```
 
-### `/refactor`
+### `/modify`
 
-Starts a structured session to refactor existing code. It helps you plan and execute changes safely and efficiently.
+Starts a structured session to modify existing code. It helps you plan and execute changes safely and efficiently.
 
 **Process:**
-1.  Asks for your high-level refactoring goals and what you want to accomplish.
-2.  Offers to create a new `git` branch for the refactoring work, isolating changes.
-3.  Generates a `REFACTOR.md` design document detailing the proposed changes.
-4.  Creates a phased `REFACTOR_IMPLEMENTATION.md` plan for your review and approval.
+
+1.  Asks for your high-level modification goals and what you want to accomplish.
+2.  Offers to create a new `git` branch for the modification work, isolating changes.
+3.  Generates a `MODIFICATION_DESIGN.md` design document detailing the proposed changes.
+4.  Creates a phased `MODIFICATION_IMPLEMENTATION.md` plan for your review and approval.
 
 ```bash
-/refactor
+/modify
 ```
 
 ### `/commit`
@@ -83,6 +85,7 @@ Starts a structured session to refactor existing code. It helps you plan and exe
 Prepares your staged `git` changes for a clean, high-quality commit. It acts as an automated pre-commit hook and message generator.
 
 **Process:**
+
 1.  Runs `dart fix` and `dart format` to clean and format your code.
 2.  Executes the Dart analyzer to check for static analysis issues.
 3.  Runs your project's test suite to ensure all tests are passing.
@@ -96,8 +99,8 @@ Prepares your staged `git` changes for a clean, high-quality commit. It acts as 
 
 This extension enforces a specific set of coding standards to ensure consistency and quality. These rules are defined in the extension's repository:
 
--   **`flutter.md`**: Contains rules and best practices for writing Dart and Flutter code. These rules are opinionated, and we encourage you to review them to ensure they align with your style.
--   **`override`**: Contains important, high-priority rules that are appended to the end of all prompts to ensure they have the most weight.
+- **`flutter.md`**: Contains rules and best practices for writing Dart and Flutter code. These rules are opinionated, and we encourage you to review them to ensure they align with your style.
+- **`override`**: Contains important, high-priority rules that are appended to the end of all prompts to ensure they have the most weight.
 
 ## 🐛 Troubleshooting
 

--- a/commands/refactor.toml
+++ b/commands/refactor.toml
@@ -2,16 +2,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# This command will be invoked via: /flutter:refactor
+# This command will be invoked via: /flutter:modify
 
-description = "Perform a refactor on your Flutter or Dart project."
+description = "Perform a modification of your Flutter or Dart project."
 
 prompt = """
-We're going to refactor some code.
+We're going to modify some code.
 
 ## Problem specification
 
-First, prompt the user for a description of the refactor's purpose, what the user wants done, and whether it should be done on a new branch.
+First, prompt the user for a description of the modification's purpose, what the user wants done, and whether it should be done on a new branch.
 
 If there are ambiguous elements, ask the user questions to clarify. When the goal is clear, or the user says to, then move on to initializing the workspace.
 
@@ -19,19 +19,19 @@ If there are ambiguous elements, ask the user questions to clarify. When the goa
 
 First, make sure there are no uncommitted changes on the current branch. If there are, notify the user and ask what they would like to do about them.
 
-If the work is to be done on a new branch, then create a new refactor branch based on the current branch, giving the branch an appropriate name if the user didn't specify one.
+If the work is to be done on a new branch, then create a new branch based on the current branch, giving the branch an appropriate name if the user didn't specify one.
 
-## Refactor design document
+## Modification design document
 
-Develop a **DETAILED** Markdown-formatted design document that follows all of the guidance you have about Dart design patterns, rules, best practices, and core principles. Save the implementation plan in REFACTOR.md in the top directory of the workspace. Feel free to use your available tools to research any aspects of the refactor that are unclear.
+Develop a **DETAILED** Markdown-formatted design document that follows all of the guidance you have about Dart design patterns, rules, best practices, and core principles. Save the implementation plan in MODIFICATION_DESIGN.md in the top directory of the workspace. Feel free to use your available tools to research any aspects of the modification that are unclear.
 
 The design doc should (at least) include:
 
 - An overview
 - A detailed analysis of the goal or problem
 - Alternatives considered
-- A detailed design for the refactor
-- Any diagrams needed to explain the refactor or the design (in Mermaid format)
+- A detailed design for the modification
+- Any diagrams needed to explain the modification or the design (in Mermaid format)
 - A summary of the design
 - References to research URLs used to arrive at the design.
 
@@ -39,7 +39,7 @@ Have the user review this design document and approve it before moving on.
 
 ## Implementation plan
 
-Develop a **DETAILED** Markdown-formatted phased implementation plan of checkboxed tasks that need to be performed in order to finish the refactor. Save the implementation plan in REFACTOR_IMPLEMENTATION.md in the top of the repo.
+Develop a **DETAILED** Markdown-formatted phased implementation plan of checkboxed tasks that need to be performed in order to finish the modification. Save the implementation plan in MODIFICATION_IMPLEMENTATION.md in the top of the repo.
 
 The implementation plan should include a section for the "Journal" which is to be updated after each phase, including checking off completed checklist items. The checklist should be updated before committing the code for the completed phase.
 
@@ -47,7 +47,7 @@ The plan must include instructions similar to: "After completing a task, if you 
 
 The plan must include updating any existing tests, creating new ones if needed, and ensuring that all tests pass before the plan is complete.
 
-The plan must also include instructions for updating any documentation that changed as a result of the refactor.
+The plan must also include instructions for updating any documentation that changed as a result of the modification.
 
 The implementation plan should specify this checklist after each phase:
 
@@ -55,8 +55,8 @@ The implementation plan should specify this checklist after each phase:
 - [ ] Run the analyze_files tool one more time and fix any issues.
 - [ ] Run any tests to make sure they all pass.
 - [ ] Run dart_format one more time to make sure that the formatting is still correct if you made any changes during the analysis and testing steps.
-- [ ] Re-read the REFACTOR_IMPLEMENTATION.md file to see what, if anything, has changed in the implementation plan, and if it has changed, take care of anything the changes imply.
-- [ ] Update the REFACTOR_IMPLEMENTATION.md file with the current state, including any learnings, surprises, or deviations in the Journal section.
+- [ ] Re-read the MODIFICATION_IMPLEMENTATION.md file to see what, if anything, has changed in the implementation plan, and if it has changed, take care of anything the changes imply.
+- [ ] Update the MODIFICATION_IMPLEMENTATION.md file with the current state, including any learnings, surprises, or deviations in the Journal section.
 - [ ] Use `git diff` to verify the changes that have been made, and create a suitable commit message for any changes, following any guidelines you have about commit messages. Be sure to properly escape dollar signs and backticks, and present the change message to the user for approval.
 - [ ] Wait for approval. Don't commit the changes or move on to the next phase of implementation until the user approves the commit.
 


### PR DESCRIPTION
# Description

This renames the `/refactor` command to be `/modify` because refactoring is a specific coding operation, and the prompt can handle modifications that aren't refactors.

Sure, it's pedantic, but I think it also is easier to understand.