### PR TITLE
Update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ The new commands will be available in new Gemini CLI sessions. The following com
 - `/modify` - Manages a structured modification session with automated planning.
 - `/commit` - Automates pre-commit checks and generates a descriptive commit message.
 
+### 3. Available Tools
+
+This extension also installs an MCP server (`flutter_launcher`) that provides tools for starting, stopping, and interacting with Flutter applications. This server is started automatically, and the following tools are made available:
+
+- `launch_app`: Launches a Flutter application on a specified device.
+- `stop_app`: Stops a running Flutter application.
+- `list_devices`: Lists all available devices that can run Flutter applications.
+- `get_app_logs`: Retrieves the logs from a running Flutter application.
+- `list_running_apps`: Lists all Flutter applications currently running that were started by this extension.
+
 ## 💡 Usage
 
 This extension provides powerful commands to automate key phases of the development lifecycle.

--- a/flutter_launcher_mcp/README.md
+++ b/flutter_launcher_mcp/README.md
@@ -47,7 +47,6 @@ The server exposes the following tools:
 
 Launches a Flutter application with specified arguments and returns its DTD URI and process ID.
 
-- **Description:** Launches a Flutter application and returns its DTD URI.
 - **Input Schema:**
 
   ```json
@@ -92,9 +91,8 @@ Launches a Flutter application with specified arguments and returns its DTD URI 
 
 #### `stop_app`
 
-Kills a running Flutter process managed by this server.
+Kills a running Flutter process started by the `launch_app` tool.
 
-- **Description:** Kills a running Flutter process started by the launch_app tool.
 - **Input Schema:**
 
   ```json
@@ -129,7 +127,6 @@ Kills a running Flutter process managed by this server.
 
 Lists available Flutter devices.
 
-- **Description:** Lists available Flutter devices.
 - **Input Schema:**
 
   ```json
@@ -158,9 +155,8 @@ Lists available Flutter devices.
 
 #### `get_app_logs`
 
-Returns the collected logs for a given flutter run process id.
+Returns the collected logs for a given flutter run process id. Can only retrieve logs started by the `launch_app` tool.
 
-- **Description:** Returns the collected logs for a given flutter run process id. Can only retrieve logs started by the launch_app tool.
 - **Input Schema:**
 
   ```json
@@ -196,9 +192,8 @@ Returns the collected logs for a given flutter run process id.
 
 #### `list_running_apps`
 
-Returns the list of running app process IDs and associated DTD URIs.
+Returns the list of running app process IDs and associated DTD URIs for apps started by the `launch_app` tool.
 
-- **Description:** Returns the list of running app process IDs and associated DTD URIs for apps started by the launch_app tool.
 - **Input Schema:**
 
   ```json

--- a/flutter_launcher_mcp/README.md
+++ b/flutter_launcher_mcp/README.md
@@ -60,11 +60,11 @@ Launches a Flutter application with specified arguments and returns its DTD URI 
       },
       "target": {
         "type": "string",
-        "description": "The main entry point file of the application."
+        "description": "The main entry point file of the application. Defaults to \"lib/main.dart\"."
       },
       "device": {
         "type": "string",
-        "description": "The device ID to launch the application on."
+        "description": "The device ID to launch the application on. To get a list of available devices to present as choices, use the list_devices tool."
       }
     },
     "required": ["root", "device"]
@@ -90,34 +90,11 @@ Launches a Flutter application with specified arguments and returns its DTD URI 
   }
   ```
 
-- **Example Call (Conceptual):**
-
-  ```dart
-  // Assuming 'client' is an initialized ServerConnection from dart_mcp
-  final launchResult = await client.callTool(
-    CallToolRequest(
-      name: 'launch_app',
-      arguments: {
-        'root': '/path/to/your/flutter/project',
-        'device': 'emulator-5554',
-      },
-    ),
-  );
-
-  if (!launchResult.isError) {
-    final dtdUri = launchResult.structuredContent!['dtdUri'] as String;
-    final pid = launchResult.structuredContent!['pid'] as int;
-    print('Flutter app launched! DTD URI: $dtdUri, PID: $pid');
-  } else {
-    print('Failed to launch Flutter app: ${launchResult.content.first.text}');
-  }
-  ```
-
 #### `stop_app`
 
 Kills a running Flutter process managed by this server.
 
-- **Description:** Kills a running Flutter process managed by this server.
+- **Description:** Kills a running Flutter process started by the launch_app tool.
 - **Input Schema:**
 
   ```json
@@ -148,23 +125,114 @@ Kills a running Flutter process managed by this server.
   }
   ```
 
-- **Example Call (Conceptual):**
+#### `list_devices`
 
-  ```dart
-  // Assuming 'client' is an initialized ServerConnection from dart_mcp
-  // and 'launchedPid' is the PID obtained from a previous launchFlutter call
-  final killResult = await client.callTool(
-    CallToolRequest(
-      name: 'stop_app',
-      arguments: {'pid': launchedPid},
-    ),
-  );
+Lists available Flutter devices.
 
-  if (!killResult.isError) {
-    final success = killResult.structuredContent!['success'] as bool;
-    print('Kill process result: $success');
-  } else {
-    print('Failed to kill process: ${killResult.content.first.text}');
+- **Description:** Lists available Flutter devices.
+- **Input Schema:**
+
+  ```json
+  {
+    "type": "object"
+  }
+  ```
+
+- **Output Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "devices": {
+        "type": "array",
+        "description": "A list of available device IDs.",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": ["devices"]
+  }
+  ```
+
+#### `get_app_logs`
+
+Returns the collected logs for a given flutter run process id.
+
+- **Description:** Returns the collected logs for a given flutter run process id. Can only retrieve logs started by the launch_app tool.
+- **Input Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "pid": {
+        "type": "integer",
+        "description": "The process ID of the flutter run process running the application."
+      }
+    },
+    "required": ["pid"]
+  }
+  ```
+
+- **Output Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "logs": {
+        "type": "array",
+        "description": "The collected logs for the process.",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": ["logs"]
+  }
+  ```
+
+#### `list_running_apps`
+
+Returns the list of running app process IDs and associated DTD URIs.
+
+- **Description:** Returns the list of running app process IDs and associated DTD URIs for apps started by the launch_app tool.
+- **Input Schema:**
+
+  ```json
+  {
+    "type": "object"
+  }
+  ```
+
+- **Output Schema:**
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "apps": {
+        "type": "array",
+        "description": "A list of running applications started by the launch_app tool.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "pid": {
+              "type": "integer",
+              "description": "The process ID of the application."
+            },
+            "dtdUri": {
+              "type": "string",
+              "description": "The DTD URI of the application."
+            }
+          },
+          "required": ["pid", "dtdUri"]
+        }
+      }
+    },
+    "required": ["apps"]
   }
   ```
 


### PR DESCRIPTION
## Description

This updates the READMEs to include information about the tools in the new MCP server.

## Summary of Changes

This pull request significantly improves the project's documentation by adding detailed information about the newly introduced MCP server and its suite of Flutter application management tools. The updates ensure that users can easily understand and utilize functionalities such as launching, stopping, logging, and listing Flutter applications, alongside managing device interactions.

### Highlights

* **Main README Update**: The primary `README.md` now includes a new section detailing the `flutter_launcher` MCP server and its associated tools.
* **New Tool Documentation**: Comprehensive documentation for `list_devices`, `get_app_logs`, and `list_running_apps` has been added to `flutter_launcher_mcp/README.md`, including their input and output schemas.
* **Documentation Refinements**: Redundant descriptions and conceptual example calls have been removed from `flutter_launcher_mcp/README.md` for `launch_app` and `stop_app`, improving conciseness.
* **Parameter Description Enhancements**: Descriptions for `target` and `device` parameters in `launch_app` were updated to provide more clarity, including default values and suggestions for device listing.
* **Tool Scope Clarification**: Descriptions for `stop_app`, `get_app_logs`, and `list_running_apps` were updated to explicitly state that they only operate on applications launched by the `launch_app` tool.

<details>
<summary><b>Changelog</b></summary>

* **README.md**
    * Added a new section "3. Available Tools" to describe the `flutter_launcher` MCP server and list its five provided tools: `launch_app`, `stop_app`, `list_devices`, `get_app_logs`, and `list_running_apps`.
* **flutter_launcher_mcp/README.md**
    * Removed a redundant "Description" line for the `launch_app` tool.
    * Updated the `target` parameter description for `launch_app` to include its default value ("lib/main.dart").
    * Updated the `device` parameter description for `launch_app` to suggest using `list_devices` for available choices.
    * Removed the "Example Call (Conceptual)" section for `launch_app`.
    * Clarified the summary for `stop_app` to indicate it kills processes started by `launch_app`.
    * Removed a redundant "Description" line for the `stop_app` tool.
    * Removed the "Example Call (Conceptual)" section for `stop_app`.
    * Added a new section documenting the `list_devices` tool, including its input and output schemas.
    * Added a new section documenting the `get_app_logs` tool, including its input and output schemas, and clarifying it only retrieves logs for apps started by `launch_app`.
    * Added a new section documenting the `list_running_apps` tool, including its input and output schemas, and clarifying it only lists apps started by `launch_app`.
</details>